### PR TITLE
Refactor layout to CSS grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
         <h1 class="title">About Me</h1>
         <div class="section-container">
             <div class="about-details-container">
-                <div class="about-containers">
+                <div class="about-grid">
                     <div class="details-container">
                         <img src="./assets/experience-light.png" alt="Experience icon" class="icon">
                         <h3>Experience</h3>
@@ -115,7 +115,7 @@
     <section id="experience">
         <p class="section__text__p1">Explore My</p>
         <h1 class="title">Experience</h1>
-        <div class="experience-details-container">
+        <div class="experience-grid">
             <div class="experience-entry">
                 <div class="logo-container">
                     <img src="./assets/temple-light.png" alt="Temple University Logo" class="icon">
@@ -186,8 +186,7 @@
     <section id="projects">
         <p class="section__text__p1">Browse My Recent</p>
         <h1 class="title">Projects</h1>
-        <div class="experience-details-container">
-            <div class="about-containers">
+        <div class="projects-grid">
                 <div class="details-container color-container">
                     <div class="article-container">
                         <img src="./assets/project-1.png" alt="Project 1" class="project-img" />
@@ -227,7 +226,6 @@
                         </button>
                     </div>
                 </div>
-            </div>
         </div>
         <img src="./assets/down-arrow-light.png" alt="Scroll down" class="icon arrow down" 
              onclick="location.href='./#contact'" aria-label="Arrow icon" style="cursor: pointer;">

--- a/mediaqueries.css
+++ b/mediaqueries.css
@@ -3,8 +3,8 @@
     height: 83vh;
     margin-bottom: 6rem;
   }
-  .about-containers {
-    flex-wrap: wrap;
+  .about-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
   #contact,
   #projects {
@@ -20,7 +20,7 @@
     display: flex;
   }
   #experience,
-  .experience-details-container {
+  .experience-grid {
     margin-top: 2rem;
   }
   #profile,
@@ -42,7 +42,7 @@
     height: 275px;
     margin: 0 auto 2rem;
   }
-  .about-containers {
+  .about-grid {
     margin-top: 0;
   }
   .experience-entry {
@@ -56,6 +56,16 @@
   }
   .text-container {
     padding-left: 0;
+  }
+}
+
+@media screen and (max-width: 900px) {
+  .about-grid,
+  .projects-grid {
+    grid-template-columns: 1fr;
+  }
+  .experience-grid {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -75,7 +85,9 @@
     height: fit-content;
     margin-bottom: 2rem;
   }
-  .about-containers,
+  .about-grid {
+    grid-template-columns: 1fr;
+  }
   .contact-info-upper-container,
   .btn-container {
     flex-wrap: wrap;
@@ -111,5 +123,17 @@
   }
   .text-container {
     text-align: justify;
+  }
+}
+
+@media screen and (min-width: 1800px) {
+  .about-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .projects-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  .experience-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/style.css
+++ b/style.css
@@ -288,20 +288,17 @@ section {
   position: relative;
 }
 
-.about-containers {
+.about-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: 2rem;
-  margin-bottom: 2rem;
-  margin-top: 2rem;
+  margin: 2rem 0;
 }
 
-.about-details-container {
-  justify-content: center;
-  flex-direction: column;
-}
-
-.about-containers,
 .about-details-container {
   display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .about-pic {
@@ -342,10 +339,11 @@ section {
   position: relative;
 }
 
-.experience-details-container {
-  display: flex;
+.experience-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
   justify-content: center;
-  flex-direction: column;
 }
 
 .experience-entry {
@@ -411,6 +409,12 @@ section {
 /* PROJECTS SECTION */
 #projects {
   position: relative;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
 }
 
 .color-container {


### PR DESCRIPTION
## Summary
- replace flex wrappers in about, experience, and project sections with grid containers
- define grid layouts in style.css
- add responsive grid breakpoints for tablet and ultrawide screens

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952ca3f450832aaed41ee054f214a1