### PR TITLE
feat: add accessible skip link to profile section

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
 <body>
+    <a href="#profile" class="skip-link">Skip to Content</a>
     <!-- Desktop Navigation -->
     <nav id="desktop-nav">
         <div class="logo">

--- a/style.css
+++ b/style.css
@@ -35,6 +35,22 @@ body {
   color: var(--text-color);
 }
 
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-100%);
+  background: var(--primary-color);
+  color: var(--background-color);
+  padding: 0.5rem 1rem;
+  transition: transform 0.3s;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 html {
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Summary
- add visually hidden "Skip to Content" link targeting the profile section
- reveal skip link on keyboard focus for both light and dark themes

## Testing
- `NODE_PATH=$(npm root -g) node - <<'NODE'
const { chromium } = require('playwright');
(async () => {
  const browser = await chromium.launch();
  const page = await browser.newPage();
  await page.goto('file://' + process.cwd() + '/index.html');
  await page.keyboard.press('Tab');
  const focused = await page.evaluate(() => document.activeElement.textContent);
  console.log('Focused element text:', focused);
  await page.keyboard.press('Enter');
  const hash = await page.evaluate(() => window.location.hash);
  console.log('Hash after activating skip link:', hash);
  await page.goto('file://' + process.cwd() + '/index.html');
  await page.evaluate(() => document.body.classList.add('dark'));
  await page.keyboard.press('Tab');
  const focusedDark = await page.evaluate(() => document.activeElement.textContent);
  console.log('Focused element text after theme toggle:', focusedDark);
  await page.keyboard.press('Enter');
  const hashDark = await page.evaluate(() => window.location.hash);
  console.log('Hash after activating skip link in dark mode:', hashDark);
  await browser.close();
})();
NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952caf135c832a9f18d13bf42a6475